### PR TITLE
1.0.2

### DIFF
--- a/loggingservice.yaml
+++ b/loggingservice.yaml
@@ -560,7 +560,6 @@ components:
         - type: object
           required:
             - target
-            - targetCallIdSip
           properties:
             target:
               type: string
@@ -1025,8 +1024,7 @@ components:
           required:
             - state
             - direction
-            - legCallId
-          properties:
+             properties:
             state:
               type: string
               description: Values limited to those in the CallStates registry

--- a/loggingservice.yaml
+++ b/loggingservice.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Logging Service
-  version: "1.0.1"
+  version: "1.0.2"
 servers:
   - url: https://api.example.com/Logging/v1
 paths:
@@ -1024,7 +1024,7 @@ components:
           required:
             - state
             - direction
-             properties:
+          properties:
             state:
               type: string
               description: Values limited to those in the CallStates registry


### PR DESCRIPTION
Removed erroneous mandatory requirements for "targetCallIdSipand" in CallTransferLogEvent and "legCallId" in CallStateChangeLogEvent and addressed comments raised by RafalK.