### PR TITLE
Fix duplicate incidentId problem in loggingservice.yaml per STA-010.3b

### DIFF
--- a/loggingservice.yaml
+++ b/loggingservice.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Logging Service
-  version: "1.2.1"
+  version: "1.2.2"
 servers:
   - url: https://api.example.com/Logging/v1
 paths:
@@ -700,37 +700,28 @@ components:
         - $ref: '#/components/schemas/LogEvent'
         - type: object
           required:
-            - incidentId
-            - mergeIncidentId
+            - incidentIdMerge
           properties:
-            incidentId:
-              type: string
-            mergeIncidentId:
+            incidentIdMerge:
               type: string
     IncidentUnMergeLogEvent:
       allOf:
         - $ref: '#/components/schemas/LogEvent'
         - type: object
           required:
-            - incidentId
-            - unmergedFromIncidentId
+            - incidentIdUnmerge
           properties:
-            incidentId:
-              type: string
-            unmergedFromIncidentId:
+            incidentIdUnmerge:
               type: string
     IncidentLinkLogEvent:
       allOf:
         - $ref: '#/components/schemas/LogEvent'
         - type: object
           required:
-            - incidentId
-            - linkedIncidentId
+            - incidentIdLinked
             - relationship
           properties:
-            incidentId:
-              type: string
-            linkedIncidentId:
+            incidentIdLinked:
               type: string
             relationship:
               type: string
@@ -740,12 +731,9 @@ components:
         - $ref: '#/components/schemas/LogEvent'
         - type: object
           required:
-            - incidentId
-            - unlinkedFromIncidentId
+             - incidentIdUnLinkedFrom
           properties:
-            incidentId:
-              type: string
-            unlinkedFromIncidentId:
+            incidentIdUnLinkedFrom:
               type: string
     IncidentClearLogEvent:
       allOf:


### PR DESCRIPTION
STA-0103b fixed the duplicate incidentId problem in the text, but the yaml was never corrected. This version corrects the yaml:
1. bumped version to 1.2.2 (adjust as needed when merging)
2. Removed duplicate incidentId from IncidentMergeLogEvent, IncidentUnmergeLogEvent, IncidentLinkLogEvent, and  IncidentUnLinkLogEvent.
2. Made the names match STA-010.3b for the members that represent the second incident id in these LogEvents. 
3. Corrected the camel case of "IncidentIdunlinkedFrom", changed it to "IncidentIdUnLinkedFrom". Should be fixed in 3b text too.
4. DID NOT modify IncidentSplitLogEvent, which also has the duplicate incidentId problem, because the text in 3b doesn't specify a new name for the second incident id - that erratum must be submitted for STA-010.3f.