### PR TITLE
NENA-STA-034.1 Log Event Updates

### DIFF
--- a/loggingservice.yaml
+++ b/loggingservice.yaml
@@ -560,6 +560,13 @@ components:
           type: object
       discriminator:
         propertyName: logEventType
+    AdditionalDataAddedLogEvent:
+      allOf:
+        - $ref: "#/components/schemas/LogEvent"
+        - type: object
+          properties:
+            block:
+              type: string
     CallProcessLogEvent:
       allOf:
         - $ref: '#/components/schemas/LogEvent'

--- a/loggingservice.yaml
+++ b/loggingservice.yaml
@@ -1086,6 +1086,8 @@ components:
               type: string
             legacyCallId:
               type: string
+            esn:
+              type: string
     HookflashLogEvent:
       allOf:
         - $ref: '#/components/schemas/LogEvent'

--- a/loggingservice.yaml
+++ b/loggingservice.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Logging Service
-  version: "1.3.0"
+  version: "1.4.0"
 servers:
   - url: https://api.example.com/Logging/v1
 paths:

--- a/loggingservice.yaml
+++ b/loggingservice.yaml
@@ -564,6 +564,8 @@ components:
       allOf:
         - $ref: "#/components/schemas/LogEvent"
         - type: object
+          required:
+            - block
           properties:
             block:
               type: string


### PR DESCRIPTION
This PR:

* Updates the GatewayCallLogEvent with a new optional `esn` member.
* Adds the new AdditionalDataAddedLogEvent schema. Note that marking the `block` member as required is not explicitly shown in NENA-STA-034.1, but has been confirmed with Terry & Randall as the intent of the document. 
* Increments the API version to 1.4.0.
